### PR TITLE
Return the time it takes to complete an API function in the results

### DIFF
--- a/pkg/nlp/transformers/bert/server.go
+++ b/pkg/nlp/transformers/bert/server.go
@@ -8,6 +8,12 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
+	"log"
+	"net/http"
+	"sort"
+	"strings"
+	"time"
+
 	"github.com/nlpodyssey/spago/pkg/mat/f64utils"
 	"github.com/nlpodyssey/spago/pkg/ml/ag"
 	"github.com/nlpodyssey/spago/pkg/ml/nn"
@@ -15,10 +21,6 @@ import (
 	"github.com/nlpodyssey/spago/pkg/nlp/tokenizers/wordpiecetokenizer"
 	"github.com/nlpodyssey/spago/pkg/utils"
 	"github.com/nlpodyssey/spago/pkg/utils/httphandlers"
-	"log"
-	"net/http"
-	"sort"
-	"strings"
 )
 
 // TODO: This code needs to be refactored. Pull requests are welcome!
@@ -145,6 +147,8 @@ const DefaultPredictedLabel = "PREDICTED"
 
 // TODO: This method is too long; it needs to be refactored.
 func (s *Server) discriminate(text string) *Response {
+	start := time.Now()
+
 	tokenizer := wordpiecetokenizer.New(s.model.Vocabulary)
 	origTokens := tokenizer.Tokenize(text)
 	groupedTokens := wordpiecetokenizer.GroupPieces(origTokens)
@@ -191,11 +195,13 @@ func (s *Server) discriminate(text string) *Response {
 			Label: label,
 		})
 	}
-	return &Response{Tokens: retTokens}
+	return &Response{Tokens: retTokens, Took: time.Since(start).Milliseconds()}
 }
 
 // TODO: This method is too long; it needs to be refactored.
 func (s *Server) predict(text string) *Response {
+	start := time.Now()
+
 	tokenizer := wordpiecetokenizer.New(s.model.Vocabulary)
 	origTokens := tokenizer.Tokenize(text)
 	tokenized := pad(tokenizers.GetStrings(origTokens))
@@ -228,7 +234,7 @@ func (s *Server) predict(text string) *Response {
 			Label: label,
 		})
 	}
-	return &Response{Tokens: retTokens}
+	return &Response{Tokens: retTokens, Took: time.Since(start).Milliseconds()}
 }
 
 type Answer struct {
@@ -247,6 +253,8 @@ func (p AnswerSlice) Sort()              { sort.Sort(p) }
 
 type QuestionAnsweringResponse struct {
 	Answers AnswerSlice `json:"answers"`
+	// Took is the number of milliseconds it took the server to execute the request.
+	Took int64 `json:"took"`
 }
 
 func (r *QuestionAnsweringResponse) Dump(pretty bool) ([]byte, error) {
@@ -270,6 +278,8 @@ const defaultMaxAnswers = 3           // TODO: from options
 
 // TODO: This method is too long; it needs to be refactored.
 func (s *Server) answer(question string, passage string) *QuestionAnsweringResponse {
+	start := time.Now()
+
 	tokenizer := wordpiecetokenizer.New(s.model.Vocabulary)
 	origQuestionTokens := tokenizer.Tokenize(question)
 	origPassageTokens := tokenizer.Tokenize(passage)
@@ -335,6 +345,7 @@ func (s *Server) answer(question string, passage string) *QuestionAnsweringRespo
 
 	return &QuestionAnsweringResponse{
 		Answers: answers,
+		Took:    time.Since(start).Milliseconds(),
 	}
 }
 
@@ -357,6 +368,8 @@ func getBestIndices(logits []float64, size int) []int {
 
 type Response struct {
 	Tokens []Token `json:"tokens"`
+	// Took is the number of milliseconds it took the server to execute the request.
+	Took int64 `json:"took"`
 }
 
 type Token struct {


### PR DESCRIPTION
Closes #18

Here are samples of the API results.

**ner-server - /analyze**

```
curl -d '{"options": {"mergeEntities": true, "filterNotEntities": true}, "text": "Mark Freuder Knopfler was born in Glasgow, Scotland, to an English mother, Louisa Mary, and a Jewish Hungarian father, Erwin Knopfler. He was the lead guitarist, singer, and songwriter for the rock band Dire Straits"}' -H "Content-Type: application/json" "http://127.0.0.1:1987/analyze?pretty"
{
    "tokens": [
        {
            "text": "Mark Freuder Knopfler",
            "start": 0,
            "end": 21,
            "label": "PER"
        },
        {
            "text": "Glasgow",
            "start": 34,
            "end": 41,
            "label": "LOC"
        },
        {
            "text": "Scotland",
            "start": 43,
            "end": 51,
            "label": "LOC"
        },
        {
            "text": "English",
            "start": 59,
            "end": 66,
            "label": "MISC"
        },
        {
            "text": "Louisa Mary",
            "start": 75,
            "end": 86,
            "label": "PER"
        },
        {
            "text": "Jewish",
            "start": 94,
            "end": 100,
            "label": "MISC"
        },
        {
            "text": "Hungarian",
            "start": 101,
            "end": 110,
            "label": "MISC"
        },
        {
            "text": "Erwin Knopfler",
            "start": 119,
            "end": 133,
            "label": "PER"
        },
        {
            "text": "Dire Straits",
            "start": 203,
            "end": 215,
            "label": "ORG"
        }
    ],
    "took": 926
}
```

**bert_server - /answer**

```
$ curl -d '{"question": "'"$QUESTION1"'", "passage": "'"$PASSAGE"'"}' -H "Content-Type: application/json" "http://127.0.0.1:1987/answer?pretty"
{
    "answers": [
        {
            "text": "Jacob Devlin",
            "start": 91,
            "end": 103,
            "confidence": 0.9641588621246571
        }
    ],
    "took": 1481
}
```

**bert_server - /discriminate**

```
$ curl -d '{"text": "'"$PASSAGE"'"}' -H "Content-Type: application/json" "http://127.0.0.1:1987/discriminate?pretty"
{
    "tokens": [
        {
            "text": "BERT",
            "start": 0,
            "end": 4,
            "label": "FAKE"
        },
        {
            "text": "is",
            "start": 5,
            "end": 7,
            "label": "FAKE"
        },
        {
            "text": "a",
            "start": 8,
            "end": 9,
            "label": "FAKE"
        },
        {
            "text": "technique",
            "start": 10,
            "end": 19,
            "label": "FAKE"
        },
        {
            "text": "for",
            "start": 20,
            "end": 23,
            "label": "FAKE"
        },
        {
            "text": "NLP",
            "start": 24,
            "end": 27,
            "label": "FAKE"
        },
        {
            "text": "developed",
            "start": 28,
            "end": 37,
            "label": "FAKE"
        },
        {
            "text": "by",
            "start": 38,
            "end": 40,
            "label": "FAKE"
        },
        {
            "text": "Google",
            "start": 41,
            "end": 47,
            "label": "FAKE"
        },
        {
            "text": ".",
            "start": 47,
            "end": 48,
            "label": "FAKE"
        },
        {
            "text": "BERT",
            "start": 49,
            "end": 53,
            "label": "FAKE"
        },
        {
            "text": "was",
            "start": 54,
            "end": 57,
            "label": "FAKE"
        },
        {
            "text": "created",
            "start": 58,
            "end": 65,
            "label": "FAKE"
        },
        {
            "text": "and",
            "start": 66,
            "end": 69,
            "label": "FAKE"
        },
        {
            "text": "published",
            "start": 70,
            "end": 79,
            "label": "FAKE"
        },
        {
            "text": "in",
            "start": 80,
            "end": 82,
            "label": "FAKE"
        },
        {
            "text": "2018",
            "start": 83,
            "end": 87,
            "label": "FAKE"
        },
        {
            "text": "by",
            "start": 88,
            "end": 90,
            "label": "FAKE"
        },
        {
            "text": "Jacob",
            "start": 91,
            "end": 96,
            "label": "FAKE"
        },
        {
            "text": "Devlin",
            "start": 97,
            "end": 103,
            "label": "FAKE"
        },
        {
            "text": "and",
            "start": 104,
            "end": 107,
            "label": "FAKE"
        },
        {
            "text": "his",
            "start": 108,
            "end": 111,
            "label": "FAKE"
        },
        {
            "text": "colleagues",
            "start": 112,
            "end": 122,
            "label": "FAKE"
        },
        {
            "text": "from",
            "start": 123,
            "end": 127,
            "label": "FAKE"
        },
        {
            "text": "Google",
            "start": 128,
            "end": 134,
            "label": "FAKE"
        },
        {
            "text": ".",
            "start": 134,
            "end": 135,
            "label": "FAKE"
        }
    ],
    "took": 1149
}
```

bert_server - /predict

```
$ curl -d '{"text": "'"$PASSAGE"'"}' -H "Content-Type: application/json" "http://127.0.0.1:1987/predict?pretty"
{
    "tokens": [],
    "took": 1137
}
```
