### PR TITLE
Enable Usage Of Custom HTTP Server

### DIFF
--- a/cmd/bert/main.go
+++ b/cmd/bert/main.go
@@ -6,11 +6,12 @@ package main
 
 import (
 	"fmt"
-	"github.com/docopt/docopt-go"
-	"github.com/nlpodyssey/spago/pkg/nlp/transformers/bert"
 	"log"
 	"os"
 	"strconv"
+
+	"github.com/docopt/docopt-go"
+	"github.com/nlpodyssey/spago/pkg/nlp/transformers/bert"
 )
 
 func main() {
@@ -43,8 +44,8 @@ Options:
 	fmt.Printf("Config: %+v\n", model.Config)
 
 	fmt.Println(fmt.Sprintf("Start server on port %d.", port))
-	server := bert.NewServer(model, port)
-	server.Start()
+	server := bert.NewServer(model)
+	server.StartDefaultServer(port)
 }
 
 func mustStr(value string, _ error) string {


### PR DESCRIPTION
# Overview

* Changes the `NewServer` function to only accept a model instead of model + port as if using an external http router, you would not need to provide the port argument
* Made existing handler functions public 
* Re-named `Start` to `StartDefaultServer` and added a comment indicating that this is only recommended if you dont need more advanced control over the HTTP server, and accepted a port argument which was removed from the `NewServer` function
  * Logic behind this is that 

Let me know if anything I changed in undesirable.

# Note

I use vscode which automatically formats imports on files I save, let me know I should omit the re-ordered imports.