### PR TITLE
fixing batchnorm epsilon constant for float32

### DIFF
--- a/pkg/ml/nn/normalization/batchnorm/batchnorm.go
+++ b/pkg/ml/nn/normalization/batchnorm/batchnorm.go
@@ -24,7 +24,7 @@ type Model struct {
 	StdDev   nn.Param `spago:"type:undefined"`
 	Momentum nn.Param `spago:"type:undefined"`
 }
-
+const epsilon = 1e-5
 const defaultMomentum = 0.9
 
 func init() {
@@ -64,7 +64,7 @@ func (m *Model) forwardTraining(xs []ag.Node) []ag.Node {
 }
 
 func (m *Model) process(g *ag.Graph, xs []ag.Node, devVector ag.Node, meanVector ag.Node) []ag.Node {
-	devVector = g.Div(m.W, g.AddScalar(devVector, g.NewScalar(1e-10)))
+	devVector = g.Div(m.W, g.AddScalar(devVector, g.NewScalar(epsilon)))
 	ys := make([]ag.Node, len(xs))
 	for i, x := range xs {
 		ys[i] = g.Add(g.Prod(g.Sub(x, meanVector), devVector), m.B)
@@ -96,7 +96,8 @@ func (m *Model) mean(xs []ag.Node) ag.Node {
 	for i := 1; i < len(xs); i++ {
 		sumVector = g.Add(sumVector, xs[i])
 	}
-	return g.DivScalar(sumVector, g.NewScalar(mat.Float(len(xs))+1e-10))
+
+	return g.DivScalar(sumVector, g.NewScalar(mat.Float(len(xs))+epsilon))
 }
 
 // StdDev computes the standard deviation of the input.
@@ -107,6 +108,6 @@ func (m *Model) stdDev(meanVector ag.Node, xs []ag.Node) ag.Node {
 		diffVector := g.Square(g.Sub(meanVector, x))
 		devVector = g.Add(devVector, diffVector)
 	}
-	devVector = g.Sqrt(g.DivScalar(devVector, g.NewScalar(mat.Float(len(xs))+1e-10)))
+	devVector = g.Sqrt(g.DivScalar(devVector, g.NewScalar(mat.Float(len(xs))+epsilon)))
 	return devVector
 }

--- a/pkg/ml/nn/normalization/batchnorm/batchnorm_test.go
+++ b/pkg/ml/nn/normalization/batchnorm/batchnorm_test.go
@@ -175,9 +175,9 @@ func TestModel_Forward(t *testing.T) {
 
 	y := rectify(g, nn.Reify(ctx, model).(*Model).Forward(x1, x2, x3)) // TODO: rewrite tests without activation function
 
-	assert.InDeltaSlice(t, []mat.Float{1.1828427, 0.2, 0.0, 0.0}, y[0].Value().Data(), 1.0e-06)
-	assert.InDeltaSlice(t, []mat.Float{0.334314, 0.2, 0.0, 0.0}, y[1].Value().Data(), 1.0e-06)
-	assert.InDeltaSlice(t, []mat.Float{1.1828427, 0.2, 0.0, 1.302356}, y[2].Value().Data(), 1.0e-06)
+	assert.InDeltaSlice(t, []mat.Float{1.1828427, 0.2, 0.0, 0.0}, y[0].Value().Data(), 1.0e-04)
+	assert.InDeltaSlice(t, []mat.Float{0.334314, 0.2, 0.0, 0.0}, y[1].Value().Data(), 1.0e-04)
+	assert.InDeltaSlice(t, []mat.Float{1.1828427, 0.2, 0.0, 1.302356}, y[2].Value().Data(), 1.0e-04)
 
 	// == Backward
 
@@ -186,11 +186,11 @@ func TestModel_Forward(t *testing.T) {
 	y[2].PropagateGrad(mat.NewVecDense([]mat.Float{0.3, -0.4, 0.7, -0.8}))
 	g.BackwardAll()
 
-	assert.InDeltaSlice(t, []mat.Float{-0.6894291116772131, 0.0, 0.0, 0.1265151774227913}, x1.Grad().Data(), 1.0e-06)
-	assert.InDeltaSlice(t, []mat.Float{-1.767774815419898e-11, 0.0, 0.0, -0.09674690039596812}, x2.Grad().Data(), 1.0e-06)
-	assert.InDeltaSlice(t, []mat.Float{0.6894291116595355, 0.0, 0.0, -0.029768277056219317}, x3.Grad().Data(), 1.0e-06)
-	assert.InDeltaSlice(t, []mat.Float{-1.0, -0.5, 0.0, -0.8}, model.B.Grad().Data(), 1.0e-06)
-	assert.InDeltaSlice(t, []mat.Float{-0.070710, -0.475556, 0.0, -1.102356}, model.W.Grad().Data(), 1.0e-06)
+	assert.InDeltaSlice(t, []mat.Float{-0.6894291116772131, 0.0, 0.0, 0.1265151774227913}, x1.Grad().Data(), 1.0e-04)
+	assert.InDeltaSlice(t, []mat.Float{-1.767774815419898e-11, 0.0, 0.0, -0.09674690039596812}, x2.Grad().Data(), 1.0e-04)
+	assert.InDeltaSlice(t, []mat.Float{0.6894291116595355, 0.0, 0.0, -0.029768277056219317}, x3.Grad().Data(), 1.0e-04)
+	assert.InDeltaSlice(t, []mat.Float{-1.0, -0.5, 0.0, -0.8}, model.B.Grad().Data(), 1.0e-04)
+	assert.InDeltaSlice(t, []mat.Float{-0.070710, -0.475556, 0.0, -1.102356}, model.W.Grad().Data(), 1.0e-04)
 }
 
 func rectify(g *ag.Graph, xs []ag.Node) []ag.Node {


### PR DESCRIPTION
When using float32, the constant used to avoid division by zero (1e-10) was too small. Replaced by 1e-5.